### PR TITLE
Off-by-One fix

### DIFF
--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -16,7 +16,8 @@ exports.unpackCode = function(str, options) {
     var m = block.match(/^(  (?:  )?)/);
     if (m) {
       var spaces = m[1];
-      var blocklines = ("\n"+block).split(new RegExp("\n"+spaces)).join('\n');
+      var blocklines = ("\n"+block).split(new RegExp("\n"+spaces));
+      blocklines = offByOneCheck(blocklines);
       if (last) {
         last += '\n' + blocklines;
         output[output.length-1] = '```' + options.lang + last + '\n```';
@@ -68,4 +69,27 @@ function eachBlock (code, fn) {
   return blocks.map(function (block) {
     return fn(block);
   }).join('\n\n');
+}
+
+/**
+ * offByOneCheck:
+ * (internal) checks spacing of first line in block to test for unnecessary sapces
+ * trims all lines down to prevent off-by-one errors, which choke a parser like Jade
+ */
+ 
+function offByOneCheck(blocklines) {
+  var testLine = blocklines[1]; // first item in array is the empty string
+  var output = [];
+  
+  // the first line in a code block shouldn't start with a space
+  // if there's a space, we can assume there's an off-by-one error
+  // so then we'll slice off the first character of all lines
+  if (/^\s/.test(testLine)) {
+    blocklines.forEach(function(line) {
+      output.push(line.slice(1));
+    });
+    return output.join('\n');
+  } else {
+    return blocklines.join('\n');
+  }
 }


### PR DESCRIPTION
This patch adds a test for an extra space at the beginning of lines of code. This specifically addresses and issue in styledown, which uses mdextract as a dependency.

In styledown, the syntax requires 3 characters at the beginning of lines (whitespace followed by asterisk followed by whitespace), which throws off the spacing when mdextract finally passes the markdown blocks to Jade.

This patch checks the first line passed to `unpackCode` for a whitespace character in the first position. If it is there, the first character of all lines is sliced off.
